### PR TITLE
[NEW FEATURE] Use btcd cookie file for authentication + bump version

### DIFF
--- a/ckpool.conf
+++ b/ckpool.conf
@@ -4,6 +4,7 @@
 		"url" : "localhost:8332",
 		"auth" : "user",
 		"pass" : "pass",
+		"cookie": "/home/user/.bitcoin/.cookie",
 		"notify" : true
 	},
 	{

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([ckpool],[0.9.8],[kernel@kolivas.org])
+AC_INIT([ckpool],[0.9.9],[kernel@kolivas.org])
 
 AC_CANONICAL_TARGET
 AC_CONFIG_MACRO_DIR([m4])

--- a/src/ckpool.c
+++ b/src/ckpool.c
@@ -1250,12 +1250,14 @@ static void parse_btcds(ckpool_t *ckp, const json_t *arr_val, const int arr_size
 	ckp->btcdurl = ckzalloc(sizeof(char *) * arr_size);
 	ckp->btcdauth = ckzalloc(sizeof(char *) * arr_size);
 	ckp->btcdpass = ckzalloc(sizeof(char *) * arr_size);
+	ckp->btcdcookie = ckzalloc(sizeof(char *) * arr_size);
 	ckp->btcdnotify = ckzalloc(sizeof(bool *) * arr_size);
 	for (i = 0; i < arr_size; i++) {
 		val = json_array_get(arr_val, i);
 		json_get_string(&ckp->btcdurl[i], val, "url");
 		json_get_string(&ckp->btcdauth[i], val, "auth");
 		json_get_string(&ckp->btcdpass[i], val, "pass");
+		json_get_string(&ckp->btcdcookie[i], val, "cookie");
 		json_get_bool(&ckp->btcdnotify[i], val, "notify");
 	}
 }
@@ -1724,6 +1726,7 @@ int main(int argc, char **argv)
 		ckp.btcdurl = ckzalloc(sizeof(char *));
 		ckp.btcdauth = ckzalloc(sizeof(char *));
 		ckp.btcdpass = ckzalloc(sizeof(char *));
+		ckp.btcdcookie = ckzalloc(sizeof(char *));
 		ckp.btcdnotify = ckzalloc(sizeof(bool));
 	}
 	for (i = 0; i < ckp.btcds; i++) {

--- a/src/ckpool.h
+++ b/src/ckpool.h
@@ -119,6 +119,7 @@ struct server_instance {
 	char *url;
 	char *auth;
 	char *pass;
+	char *cookie;
 	bool notify;
 	bool alive;
 	connsock_t cs;
@@ -225,6 +226,7 @@ struct ckpool_instance {
 	char **btcdurl;
 	char **btcdauth;
 	char **btcdpass;
+	char **btcdcookie;
 	bool *btcdnotify;
 	int blockpoll; // How frequently in ms to poll bitcoind for block updates
 	int nonce1length; // Extranonce1 length


### PR DESCRIPTION
Hi, 

Getting the reference from this [commit](https://github.com/golden-guy/ckpool-solo/commit/3df23a6f4335591fc6f48de394d1b16df995dbdd), I replicated with the needed configuration to enable the cookie authentication with btcd on "nerdminer" branch

Also, I modified the version according to the latest 0.9.9

BTW: is it possible to use this version of the software (branch "nerdminer") too with another miner different from nerdminer (i.e bitaxe) without config modifications?